### PR TITLE
Fix select, checkbox and radios in Safari

### DIFF
--- a/doodle.css
+++ b/doodle.css
@@ -108,6 +108,7 @@
 }
 
 .doodle select {
+  -webkit-appearance: none;
   appearance: none;
   padding-right: 1.5em;
   background: url(caret.svg) no-repeat right transparent;
@@ -137,6 +138,7 @@
 }
 
 .doodle input[type="checkbox"], .doodle input[type="radio"] {
+  -webkit-appearance: none;
   appearance: none;
   outline: 0;
   background: transparent;


### PR DESCRIPTION
Safari on both iOS and macOS still requires the -webkit vendor prefix in order to style checkbox, radio and select elements.

Demo page before (Safari 15.1 on macOS 12.0.1):
<img width="549" alt="image" src="https://user-images.githubusercontent.com/1253214/146219060-62459efe-80df-489e-a604-852057fb9b37.png">

After:
<img width="570" alt="image" src="https://user-images.githubusercontent.com/1253214/146219191-4cc75c48-ed56-4c96-a196-0a70bfbf342f.png">
