### PR TITLE
Update the documentation with import indications for the npm package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ There's also an npm installable version:
 npm install doodle.css
 ```
 
+The npm package can be imported with:
+
+```
+import 'doodle.css/doodle.css'
+```
+
 There are are bunch of other vectors you can use in [doodles.svg](./doodles.svg).
 
 You can also put a doodle box around anything using the class `.doodle .border` or `.doodle-border`.


### PR DESCRIPTION
It was a bit hard to figure out where the doodle.css can be imported from. In order to find this I had to look through node_modules. I think this additional line could be useful.