### PR TITLE
Give buttons a different color when disabled

### DIFF
--- a/doodle.css
+++ b/doodle.css
@@ -128,6 +128,10 @@
   color: #3c3c3c;
 }
 
+.doodle button:disabled {
+  color: grey;
+}
+
 .doodle input[type="checkbox"] {
   border-width: 6px 6px 6px 6px;
   border-image: url(checkbox.svg) 6 6 6 6 stretch stretch;


### PR DESCRIPTION
- Checkboxes and radio buttons already have a different appearance when disabled, so just extend this to buttons as well (use the same color: grey)